### PR TITLE
Added extension to query and mutate

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -33,18 +33,36 @@ func NewClient(url string, httpClient *http.Client) *Client {
 // with a query derived from q, populating the response into it.
 // q should be a pointer to struct that corresponds to the GraphQL schema.
 func (c *Client) Query(ctx context.Context, q any, variables map[string]any) error {
-	return c.do(ctx, queryOperation, q, variables)
+	return c.do(ctx, queryOperation, q, variables, nil)
+}
+
+// QueryWithExtensions executes a single GraphQL query request,
+// with a query derived from q, populating the response into it.
+// q should be a pointer to struct that corresponds to the GraphQL schema.
+// Additionally, this will capture the extensions from the response.
+// extensions should be a pointer that corresponds to the extensions schema.
+func (c *Client) QueryWithExtensions(ctx context.Context, q interface{}, variables map[string]interface{}, extensions interface{}) error {
+	return c.do(ctx, queryOperation, q, variables, extensions)
 }
 
 // Mutate executes a single GraphQL mutation request,
 // with a mutation derived from m, populating the response into it.
 // m should be a pointer to struct that corresponds to the GraphQL schema.
 func (c *Client) Mutate(ctx context.Context, m any, variables map[string]any) error {
-	return c.do(ctx, mutationOperation, m, variables)
+	return c.do(ctx, mutationOperation, m, variables, nil)
+}
+
+// MutateWithExtensions executes a single GraphQL mutation request,
+// with a mutation derived from m, populating the response into it.
+// m should be a pointer to struct that corresponds to the GraphQL schema.
+// Additionally, this will capture the extensions from the response.
+// extensions should be a pointer that corresponds to the extensions schema.
+func (c *Client) MutateWithExtensions(ctx context.Context, m interface{}, variables map[string]interface{}, extensions interface{}) error {
+	return c.do(ctx, mutationOperation, m, variables, extensions)
 }
 
 // do executes a single GraphQL operation.
-func (c *Client) do(ctx context.Context, op operationType, v any, variables map[string]any) error {
+func (c *Client) do(ctx context.Context, op operationType, v any, variables map[string]any, extensions any) error {
 	var query string
 	switch op {
 	case queryOperation:
@@ -79,9 +97,9 @@ func (c *Client) do(ctx context.Context, op operationType, v any, variables map[
 		return fmt.Errorf("non-200 OK status code: %v body: %q", resp.Status, body)
 	}
 	var out struct {
-		Data   *json.RawMessage
-		Errors errors
-		//Extensions any // Unused.
+		Data       *json.RawMessage
+		Errors     errors
+		Extensions *json.RawMessage
 	}
 	err = json.NewDecoder(resp.Body).Decode(&out)
 	if err != nil {
@@ -90,6 +108,13 @@ func (c *Client) do(ctx context.Context, op operationType, v any, variables map[
 	}
 	if out.Data != nil {
 		err := jsonutil.UnmarshalGraphQL(*out.Data, v)
+		if err != nil {
+			// TODO: Consider including response body in returned error, if deemed helpful.
+			return err
+		}
+	}
+	if extensions != nil && out.Extensions != nil {
+		err := jsonutil.UnmarshalGraphQL(*out.Extensions, extensions)
 		if err != nil {
 			// TODO: Consider including response body in returned error, if deemed helpful.
 			return err


### PR DESCRIPTION
The original package doesn't return an "extension" data containing data on the rate limit.
So, adding the methods containing extensions is needed to check for the rate limit and if it isn't reached.
structured like the following:
"extensions": {
    "cost": {
      "requestedQueryCost": 1,
      "actualQueryCost": 1,
      "throttleStatus": {
        "maximumAvailable": 1000,
        "currentlyAvailable": 999,
        "restoreRate": 50
      }
    }

### WARNING:
- if future updates of this package occur and conflict happens, consider if receiving a rate limit like this is the best method.